### PR TITLE
Split center-out spectrum into left/right halves

### DIFF
--- a/mkyt
+++ b/mkyt
@@ -215,7 +215,7 @@ elif [[ "$viz" == "spectrum" ]]; then
   viz_vertical=""
   (( spectro_vertical )) && viz_vertical=",transpose=2"
   if (( spectro_center )); then
-    vizf="[1:a]showspectrum=s=${width}x${vizh}:mode=combined:scale=log:slide=scroll:legend=disabled:win_func=hann:overlap=0.8:color=${palette},format=rgba[s];[s]hflip[sf];[s]crop=iw/2:ih:iw/2:0[right];[sf]crop=iw/2:ih:0:0[left];[left][right]hstack=inputs=2${viz_vertical}[viz];"
+    vizf="[1:a]showspectrum=s=${width}x${vizh}:mode=combined:scale=log:slide=scroll:legend=disabled:win_func=hann:overlap=0.8:color=${palette},format=rgba[s];[s]split=2[s0][s1];[s0]hflip,crop=iw/2:ih:0:0[left];[s1]crop=iw/2:ih:iw/2:0[right];[left][right]hstack=inputs=2${viz_vertical}[viz];"
   else
     vizf="[1:a]showspectrum=s=${width}x${vizh}:mode=combined:scale=log:slide=${spectro_scroll}:legend=disabled:win_func=hann:overlap=0.8:color=${palette}${viz_vertical}[viz];"
   fi


### PR DESCRIPTION
## Summary
- Split center-out spectrum output into left/right halves before hstack

## Testing
- `./mkyt --help > /tmp/mkyt_help.txt 2>&1 ; tail -n +1 /tmp/mkyt_help.txt`


------
https://chatgpt.com/codex/tasks/task_e_68aede3969b48329a1eaa8f0d2eca7f3