### PR TITLE
Add flag to stack visualizers under cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Options (all optional):
   --spectro-scroll <scroll|rscroll|fullframe|replace>  Spectrum slide mode (default: scroll)
   --spectro-center  Center-out spectrum (new data at center)
   --spectro-vertical Vertical spectrum layout (rotate 90° CCW)
+  --viz-below       Stack visualizer under the cover (extends canvas; alias --spectro-below)
 Examples (covering every feature)
 1) No visualizer (default)
 bash
@@ -161,6 +162,8 @@ mkyt waveform --auto-color -B
 
 # different waveform look + smaller height + margin from edge
 mkyt waveform -m p2p -H 240 -M 12
+# stack waveform below the cover image
+mkyt waveform --viz-below -B
 3) Scrolling spectrum strip
 bash
 Copy
@@ -173,6 +176,8 @@ mkyt spectrum -K rainbow -H 280 -M 16 -B
 
 # place spectrum at the top
 mkyt spectrum -A top -B
+# stack spectrum below the cover image
+mkyt spectrum --viz-below -B
 4) Bar analyzer (“dance” look)
 bash
 Copy
@@ -180,6 +185,7 @@ Edit
 mkyt bars                        # default bars at bottom
 mkyt bars -H 260 -M 12 -B        # shorter with margin and black strip
 mkyt bars -A center              # centered bar block over image
+mkyt bars --viz-below -B         # stack bars below the cover image
 5) Placement, margins, and contrast bar
 bash
 Copy

--- a/mkyt
+++ b/mkyt
@@ -33,6 +33,7 @@ Options (all optional):
   --spectro-scroll <scroll|rscroll|fullframe|replace>  Spectrum slide mode (default: scroll)
   --spectro-center  Center-out spectrum (new data at center)
   --spectro-vertical Vertical spectrum layout (rotate 90° CCW)
+  --viz-below       Stack visualizer under the cover (extends canvas; alias --spectro-below)
 
 Examples:
   mkyt
@@ -109,6 +110,8 @@ vizh=300 align="bottom" margin=0 fps=25
 rect=0 rect_color="black@0.45" black_flag=0
 wf_mode="line" palette="intensity"
 spectro_scroll="scroll" spectro_center=0 spectro_vertical=0
+# place visualizer below cover
+viz_below=0
 abr="320k" sr=48000 crf=18 preset="medium" auto_color=0
 
 # --- pre-parse positional + long flags (so getopts won’t choke) ---
@@ -119,6 +122,7 @@ while [[ $# -gt 0 ]]; do
     --spectro-scroll) spectro_scroll="$2"; shift 2 ;;
     --spectro-center) spectro_center=1; shift ;;
     --spectro-vertical) spectro_vertical=1; shift ;;
+    --viz-below|--spectro-below) viz_below=1; shift ;;
     --) shift; break ;;                   # end of options
     -*) break ;;                          # let getopts handle
     *) echo "Unknown argument: $1"; usage; exit 2 ;;
@@ -191,16 +195,24 @@ if [[ -n "$iw_ih" ]]; then
 fi
 : "${width:=1920}"; : "${height:=1080}"
 
-# Show entire image, pad to fit output (no cropping)
-bgf="[0:v]scale=${width}:${height}:force_original_aspect_ratio=decrease,pad=${width}:${height}:(ow-iw)/2:(oh-ih)/2[bg];"
+if (( viz_below )); then
+  base_h=$height
+  height=$(( base_h + margin + vizh ))
+  bgf="[0:v]scale=${width}:${base_h}:force_original_aspect_ratio=decrease,pad=${width}:${height}:(ow-iw)/2:0[bg];"
+  bar_y=$(( base_h + margin ))
+  overlay_y=$bar_y
+else
+  # Show entire image, pad to fit output (no cropping)
+  bgf="[0:v]scale=${width}:${height}:force_original_aspect_ratio=decrease,pad=${width}:${height}:(ow-iw)/2:(oh-ih)/2[bg];"
 
-# Y positions
-case "$align" in
-  bottom) bar_y="ih-${rect}-${margin}"; overlay_y="main_h-overlay_h-${margin}" ;;
-  top)    bar_y="${margin}";             overlay_y="${margin}" ;;
-  center) bar_y="(ih-${rect})/2";        overlay_y="(main_h-overlay_h)/2" ;;
-  *) echo "Invalid -A '$align' (use bottom|top|center)"; exit 2 ;;
-esac
+  # Y positions
+  case "$align" in
+    bottom) bar_y="ih-${rect}-${margin}"; overlay_y="main_h-overlay_h-${margin}" ;;
+    top)    bar_y="${margin}";             overlay_y="${margin}" ;;
+    center) bar_y="(ih-${rect})/2";        overlay_y="(main_h-overlay_h)/2" ;;
+    *) echo "Invalid -A '$align' (use bottom|top|center)"; exit 2 ;;
+  esac
+fi
 
 # -B → black strip the size of the viz
 (( black_flag )) && { rect="$vizh"; rect_color="black@1"; }
@@ -215,7 +227,7 @@ elif [[ "$viz" == "spectrum" ]]; then
   viz_vertical=""
   (( spectro_vertical )) && viz_vertical=",transpose=2"
   if (( spectro_center )); then
-    vizf="[1:a]showspectrum=s=${width}x${vizh}:mode=combined:scale=log:slide=scroll:legend=disabled:win_func=hann:overlap=0.8:color=${palette},format=rgba[s];[s]hflip[sf];[s]crop=iw/2:ih:iw/2:0[right];[sf]crop=iw/2:ih:0:0[left];[left][right]hstack=inputs=2${viz_vertical}[viz];"
+    vizf="[1:a]showspectrum=s=${width}x${vizh}:mode=combined:scale=log:slide=scroll:legend=disabled:win_func=hann:overlap=0.8:color=${palette},format=rgba[s];[s]split=2[s0][s1];[s0]hflip,crop=iw/2:ih:0:0[left];[s1]crop=iw/2:ih:iw/2:0[right];[left][right]hstack=inputs=2${viz_vertical}[viz];"
   else
     vizf="[1:a]showspectrum=s=${width}x${vizh}:mode=combined:scale=log:slide=${spectro_scroll}:legend=disabled:win_func=hann:overlap=0.8:color=${palette}${viz_vertical}[viz];"
   fi


### PR DESCRIPTION
## Summary
- generalize `--spectro-below` to `--viz-below` so any visualizer can render beneath the cover image
- document the new option with waveform, spectrum, and bar examples

## Testing
- `./mkyt --help > /tmp/help.txt 2>&1 ; tail -n +1 /tmp/help.txt`


------
https://chatgpt.com/codex/tasks/task_e_68aede3969b48329a1eaa8f0d2eca7f3