### PR TITLE
fix: ensure output passed as file

### DIFF
--- a/mkyt
+++ b/mkyt
@@ -255,5 +255,5 @@ ffmpeg -n -loop 1 -i "$cover" -i "$audio" \
   -filter_complex "$filter_complex" -map "[v]" -map 1:a \
   -c:v libx264 -tune stillimage -crf "$crf" -preset "$preset" -pix_fmt yuv420p \
   "${audio_args[@]}" -metadata title="$title" \
-  -shortest -movflags +faststart "$out"
+  -shortest -movflags +faststart -- "$out"
 


### PR DESCRIPTION
## Summary
- ensure the script forces ffmpeg to treat output path as a filename by inserting `--` before the output argument

## Testing
- `./mkyt -h`
- `./mkyt` *(fails: ffmpeg not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b04e03915083298ca4bfbedecfafc9